### PR TITLE
fix: download package with specific version from pypi

### DIFF
--- a/makePipRecipes.py
+++ b/makePipRecipes.py
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     print('Note: Consider the exact writing! Case sensitive!')
     print('You can find Python pip packages here: https://pypi.org/')
     PipName =input('PiP-Package Name: ')
-    Pipurl = PipName
+    Pipurl = re.sub(r"\-(\d+\.\d+\.\d+).*", r"==\1", PipName)
 
     if PipName=='q' or PipName=='Q': sys.exit()
     if PipName.endswith('.whl'):


### PR DESCRIPTION
- pypi.org expect exact version of package to be "=="

This fixed error when tried to run script with "charset-normalizer-2.0.12" previously resulted in following:

```
--> Download for testing the Python PiP package
ERROR: Could not find a version that satisfies the requirement charset-normalizer-2.0.12 (from versions: none)
ERROR: No matching distribution found for charset-normalizer-2.0.12
```